### PR TITLE
残りのタスクまとめやっちゃいました。

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -10,7 +10,7 @@
     content="やるべきことが多様化してきたこの時代。「色々やるべきことはあるけど、とりあえずこれだけはやりきりたい」と思ったことはありませんか？ Must Do はそんなあなたをサポート！ このサービスではタスクを1つだけ設定できて、タスク登録時にそれをツイートします。 そのタスクを完了しない限り、他のタスクは設定できません。 Tweet していることにより、後を戻れなくしてタスクをやる推進力を手に入れられます。 Must Do で、あなたの Todo を絶対に Do してあげましょう！" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta property="og:url" content="http://bits.blogs.nytimes.com/2011/12/08/a-twitter-for-my-sister/" />
-  <meta property="og:title" content="Must Do" />
+  <meta property="og:title" content="とにかく一つのことをやりきるためのToDoアプリ - Must Do" />
   <meta property="og:description"
     content="やるべきことが多様化してきたこの時代。「色々やるべきことはあるけど、とりあえずこれだけはやりきりたい」と思ったことはありませんか？ Must Do はそんなあなたをサポート！ このサービスではタスクを1つだけ設定できて、タスク登録時にそれをツイートします。 そのタスクを完了しない限り、他のタスクは設定できません。 Tweet していることにより、後を戻れなくしてタスクをやる推進力を手に入れられます。 Must Do で、あなたの Todo を絶対に Do してあげましょう！" />
   <meta property="og:image" content="https://mustdo.tsurumiii.vercel.app/must_do_ogp.png" />

--- a/src/common/images/homeIcon.svg
+++ b/src/common/images/homeIcon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="#FF8971" width="18px" height="18px">
+  <path d="M0 0h24v24H0V0z" fill="none"/>
+  <path d="M12 5.69l5 4.5V18h-2v-6H9v6H7v-7.81l5-4.5M12 3L2 12h3v8h6v-6h2v6h6v-8h3L12 3z"/>
+</svg>

--- a/src/presentation/pages/history/History.tsx
+++ b/src/presentation/pages/history/History.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from "react"
 import { Todo } from "../../../domain/entities"
 import { useTodoHistory } from "../../../domain/hooks/history/HistoryHooks"
-import watchIcon from "../../../common/images/watch.svg"
+import { useHistory } from 'react-router-dom'
 import { DateHelper } from "../../../common/helper"
 import navigateIcon from "../../../common/images/navigate.svg"
-import { useHistory } from 'react-router-dom'
+import home from '../../../common/images/homeIcon.svg'
+import watchIcon from "../../../common/images/watch.svg"
 
 export const History = (): JSX.Element => {
   const { fetchTodoHistory, removeTodoHistory } = useTodoHistory()
@@ -37,10 +38,11 @@ export const History = (): JSX.Element => {
     <div className="min-h-screen bg-bg-main">
       <header className="fixed w-full h-16 bg-white shadow flex justify-center items-center">
         <p className="text-center text-title font-bold">完了したタスク</p>
-        <img onClick={onClickBack} className="fixed left-4 h-8 cursor-pointer" src={navigateIcon} alt="" />
+        <img onClick={onClickBack} className="md:hidden fixed left-4 h-8 cursor-pointer" src={navigateIcon} alt="" />
+        <img onClick={onClickBack} className="hidden md:block fixed right-4 h-8 cursor-pointer" src={home} alt="" />
         {/* <p className="fixed right-4 h-4" onClick={removeTodoHistory}>削除</p> */}
       </header>
-      <main className="flex flex-col items-center pt-24 container">
+      <main className="flex flex-col items-center pt-24 pb-48 container">
         {
           todoHistory.length === 0 ?
             <p>まだ完了したタスクはありません。</p>
@@ -53,7 +55,7 @@ export const History = (): JSX.Element => {
                       <p className="text-text">{todo.title}</p>
                       <div className="flex mt-2">
                         <img className="" src={watchIcon} alt="" />
-                        <p className="text-orange-50 mx-1">{getDate(todo)}</p>
+                        <p className="text-orange-50 mx-1 text-sm">{getDate(todo)}</p>
                       </div>
                     </div>
                   )

--- a/src/presentation/pages/top/Top.tsx
+++ b/src/presentation/pages/top/Top.tsx
@@ -115,10 +115,11 @@ export const Top = (): JSX.Element => {
                   type="text"
                   value={title}
                   onChange={e => setTitle(e.target.value)}
+                  maxLength={80}
                   placeholder="タスクを入力"
                   className="focus:border-indigo-500 block h-10 w-full pl-3 pr-12 md:text-sm border-gray-300 rounded-sm"
                 />
-                <p className={title.length > 80 ? 'text-red-500' : ''}>{title.length}/80</p>
+                <p className={title.length >= 80 ? 'text-red-500' : ''}>{title.length}/80</p>
                 <button
                   className="mt-4 py-4 md:py-2 w-full md:px-20 font-semibold rounded-lg hover:shadow-xl shadow-md placeholder-textGray text-white bg-button1"
                   onClick={() => {

--- a/src/presentation/pages/top/Top.tsx
+++ b/src/presentation/pages/top/Top.tsx
@@ -98,7 +98,7 @@ export const Top = (): JSX.Element => {
   return (
     <div className="h-screen bg-bg-main font-sans">
       <header className="h-16 bg-white shadow flex justify-center items-center">
-        <img className="h-6" src={logo} alt="" />
+        <img className="h-6 w-28 md:w-32" src={logo} alt="" />
         <img
           className="fixed right-4 h-4 cursor-pointer"
           src={checkIcon}
@@ -110,7 +110,7 @@ export const Top = (): JSX.Element => {
         <div className="md:w-1/2 w-full">
           {
             currentTodo === undefined ?
-              <>
+              <div className="flex flex-col items-end">
                 <input
                   type="text"
                   value={title}
@@ -118,16 +118,17 @@ export const Top = (): JSX.Element => {
                   placeholder="タスクを入力"
                   className="focus:border-indigo-500 block h-10 w-full pl-3 pr-12 md:text-sm border-gray-300 rounded-sm"
                 />
+                <p className={title.length > 80 ? 'text-red-500' : ''}>{title.length}/80</p>
                 <button
-                  className="mt-4 py-4 md:py-2 w-full lg:w-auto xl:w-1/2 md:px-20 font-semibold rounded-lg hover:shadow-xl shadow-md placeholder-textGray text-white bg-button1"
+                  className="mt-4 py-4 md:py-2 w-full md:px-20 font-semibold rounded-lg hover:shadow-xl shadow-md placeholder-textGray text-white bg-button1"
                   onClick={() => {
-                    if (title.length === 0) return
+                    if (title.length === 0 || title.length > 80) return
                     setIsStartModalOpen(true)
                   }}
                 >
                   タスクを登録
                 </button>
-              </> :
+              </div> :
               <>
                 <div className="bg-white px-4 py-3 shadow-md rounded">
                   <h1 className="text-text font-bold">{currentTodo.title}</h1>


### PR DESCRIPTION
- PC画面で右上のチェックで一覧に移動した後、同じ場所にHomeIconを置いてホームに戻れるようにする
- 完了したタスクページの下の余白もうちょい当てた方が良さそう
- 完了したタスクの時間の文字を小さくする
- Mustdoのロゴの右端の見切れを調整する
- タスクの文字数上限を80文字にする
- title にサブタイトルを入れる